### PR TITLE
CWRC-946: Metadata blocks need to be configurable.

### DIFF
--- a/islandora_blocks.module
+++ b/islandora_blocks.module
@@ -179,6 +179,10 @@ function islandora_blocks_metadata_form($form, &$form_state) {
   if (module_exists('islandora_solr_metadata')) {
     $metadata_toggle_options['solr_metadata'] = t('Indexed (Solr) Metadata');
 
+    // Find the fields we should query and display.
+    module_load_include('inc', 'islandora_solr_metadata', 'includes/db');
+    $associations = islandora_solr_metadata_get_associations_by_cmodels($object->models);
+
     // Render the object's Solr metadata.
     $form['solr_metadata'] = array(
       '#type' => 'container',
@@ -186,6 +190,7 @@ function islandora_blocks_metadata_form($form, &$form_state) {
         '#theme' => 'islandora_solr_metadata_display',
         '#islandora_object' => $object,
         '#print' => TRUE,
+        '#associations' => $associations,
       ),
       '#states' => array(
         'visible' => array(

--- a/islandora_blocks.module
+++ b/islandora_blocks.module
@@ -52,13 +52,13 @@ function islandora_blocks_block_view($delta = '') {
   // If there is no object there are no blocks.
   $object = menu_get_object('islandora_object', 2);
   if (!$object) {
-    return false;
+    return FALSE;
   }
 
   // We should be on the "view" callback.
   $menu_item = menu_get_item();
   if ($menu_item['path'] != 'islandora/object/%/view' && $menu_item['path'] != 'islandora/object/%') {
-    return false;
+    return FALSE;
   }
 
   $block = array();
@@ -77,16 +77,16 @@ function islandora_blocks_block_view($delta = '') {
         '#type' => 'ul',
         '#items' => array(),
       );
-      $parents = $object->relationships->get(null, 'isMemberOfCollection');
+      $parents = $object->relationships->get(NULL, 'isMemberOfCollection');
       if (count($parents) == 0) {
-        return false;
+        return FALSE;
       }
-      $return = false;
+      $return = FALSE;
       foreach ($parents as $parent) {
         try {
           $obj = islandora_object_load($parent['object']['value']);
           if ($obj) {
-            $return = true;
+            $return = TRUE;
             $block['content']['#items'][] = l($obj->label, 'islandora/object/' . $obj->id);
           }
         } catch (Exception $e) {}
@@ -94,7 +94,7 @@ function islandora_blocks_block_view($delta = '') {
 
       // Couldn't load any parents, return nothing.
       if (!$return) {
-        return false;
+        return FALSE;
       }
       break;
 
@@ -129,7 +129,7 @@ function islandora_blocks_block_view($delta = '') {
     case 'citation':
       // To provide a citation we need a MODS record.
       if (!isset($object['MODS'])) {
-        return false;
+        return FALSE;
       }
       $block['subject'] = t('Citation');
       $block['content'] = citeproc_bibliography_from_mods(citeproc_style(variable_get('islandora_blocks_citation_style')), $object['MODS']->content);

--- a/islandora_blocks.module
+++ b/islandora_blocks.module
@@ -195,16 +195,14 @@ function islandora_blocks_configure_validate($form, &$form_state) {
  * @ingroup forms
  */
 function islandora_blocks_metadata_form($form, &$form_state) {
-  $metadata_toggle_options = array();
+  $metadata_toggle_options = _islandora_blocks_available_metadata_sets();
 
   // The Fedora object should be the first build argument.
   $object = reset($form_state['build_info']['args']);
 
   // If the Solr metadata is available, add an option to the toggle and display
   // that container.
-  if (module_exists('islandora_solr_metadata')) {
-    $metadata_toggle_options['solr_metadata'] = t('Indexed (Solr) Metadata');
-
+  if (array_key_exists('solr_metadata', $metadata_toggle_options)) {
     // Find the fields we should query and display.
     module_load_include('inc', 'islandora_solr_metadata', 'includes/db');
     $associations = islandora_solr_metadata_get_associations_by_cmodels($object->models);
@@ -228,9 +226,7 @@ function islandora_blocks_metadata_form($form, &$form_state) {
 
   // If the Islandora module is available, add an option to the toggle and
   // display that container.
-  if (module_exists('islandora')) {
-    $metadata_toggle_options['dc_metadata'] = t('Basic (Dublin Core) Metadata');
-
+  if (array_key_exists('dc_metadata', $metadata_toggle_options)) {
     // Render the object's DC metadata.
     $form['dc_metadata'] = array(
       '#type' => 'container',
@@ -258,4 +254,35 @@ function islandora_blocks_metadata_form($form, &$form_state) {
   );
 
   return $form;
+}
+
+/* Helper functions. */
+
+/**
+ * Return a list of available metadata sets.
+ *
+ * @return array
+ *   An associative array of zero or more metadata sets:
+ *   - solr_metadata: Indexed (Solr) Metadata
+ *   - dc_metadata: Basic (Dublin Core) Metadata
+ */
+function _islandora_blocks_available_metadata_sets() {
+  // Cache metadata sets per request.
+  $available_metadata_sets = &drupal_static(__FUNCTION__);
+  if (!isset($available_metadata_sets)) {
+    $available_metadata_sets = array();
+
+    // If the Islandora Solr Metadata module is installed, we can display
+    // Indexed Solr metadata.
+    if (module_exists('islandora_solr_metadata')) {
+      $available_metadata_sets['solr_metadata'] = t('Indexed (Solr) Metadata');
+    }
+
+    // If the Islandora module is available, we can display DC metadata.
+    if (module_exists('islandora')) {
+      $available_metadata_sets['dc_metadata'] = t('Basic (Dublin Core) Metadata');
+    }
+  }
+
+  return $available_metadata_sets;
 }

--- a/islandora_blocks.module
+++ b/islandora_blocks.module
@@ -89,7 +89,10 @@ function islandora_blocks_block_view($delta = '') {
             $return = TRUE;
             $block['content']['#items'][] = l($obj->label, 'islandora/object/' . $obj->id);
           }
-        } catch (Exception $e) {}
+        }
+        catch (Exception $e) {
+          // No-op.
+        }
       }
 
       // Couldn't load any parents, return nothing.
@@ -122,7 +125,9 @@ function islandora_blocks_block_view($delta = '') {
             '#datastreams' => $datastreams,
           );
         }
-        catch (RepositoryException $e) {}
+        catch (RepositoryException $e) {
+          // No-op.
+        }
       }
       break;
 

--- a/islandora_blocks.module
+++ b/islandora_blocks.module
@@ -58,12 +58,10 @@ function islandora_blocks_block_view($delta = '') {
   $block = array();
   switch ($delta) {
     case 'metadata':
+      $form = drupal_get_form('islandora_blocks_metadata_form', $object);
+
       $block['subject'] = t('Metadata');
-      $block['content'] = array(
-        '#theme' => 'islandora_dublin_core_display',
-        '#islandora_object' => $object,
-        '#print' => true,
-      );
+      $block['content'] = drupal_render($form);
       break;
 
     case 'collections':
@@ -156,4 +154,64 @@ function islandora_blocks_block_configure($delta = '') {
 
 function islandora_blocks_configure_validate($form, &$form_state) {
   variable_set('islandora_blocks_citation_style', $form_state['values']['islandora_blocks_citation_style']);
+}
+
+/**
+ * Form callback: Form constructor for a display of metadata.
+ *
+ * @param array $form
+ *   The form object.
+ * @param array &$form_state
+ *   The form state object. Must contain the Fedora object that we want to
+ *   display the metadata form as the first item in the array at
+ *   $form_state['build_info']['args'].
+ *
+ * @ingroup forms
+ */
+function islandora_blocks_metadata_form($form, &$form_state) {
+  // The Fedora object should be the first build argument.
+  $object = reset($form_state['build_info']['args']);
+
+  // Add a form control to toggle the visbile metadata.
+  $form['metadata_toggle'] = array(
+    '#type' => 'radios',
+    '#title' => t('Metadata to display'),
+    '#options' => array(
+      'dc_metadata' => t('Object metadata'),
+      'solr_metadata' => t('Solr metadata'),
+    ),
+    '#default_value' => 'dc_metadata',
+  );
+
+  // Render the object's DC metadata.
+  $form['dc_metadata'] = array(
+    '#type' => 'container',
+    'metadata' => array(
+      '#theme' => 'islandora_dublin_core_display',
+      '#islandora_object' => $object,
+      '#print' => TRUE,
+    ),
+    '#states' => array(
+      'visible' => array(
+        ':input[name="metadata_toggle"]' => array('value' => 'dc_metadata'),
+      ),
+    ),
+  );
+
+  // Render the object's Solr metadata.
+  $form['solr_metadata'] = array(
+    '#type' => 'container',
+    'metadata' => array(
+      '#theme' => 'islandora_solr_metadata_display',
+      '#islandora_object' => $object,
+      '#print' => TRUE,
+    ),
+    '#states' => array(
+      'visible' => array(
+        ':input[name="metadata_toggle"]' => array('value' => 'solr_metadata'),
+      ),
+    ),
+  );
+
+  return $form;
 }

--- a/islandora_blocks.module
+++ b/islandora_blocks.module
@@ -169,48 +169,61 @@ function islandora_blocks_configure_validate($form, &$form_state) {
  * @ingroup forms
  */
 function islandora_blocks_metadata_form($form, &$form_state) {
+  $metadata_toggle_options = array();
+
   // The Fedora object should be the first build argument.
   $object = reset($form_state['build_info']['args']);
 
+  // If the Solr metadata is available, add an option to the toggle and display
+  // that container.
+  if (module_exists('islandora_solr_metadata')) {
+    $metadata_toggle_options['solr_metadata'] = t('Indexed (Solr) Metadata');
+
+    // Render the object's Solr metadata.
+    $form['solr_metadata'] = array(
+      '#type' => 'container',
+      'metadata' => array(
+        '#theme' => 'islandora_solr_metadata_display',
+        '#islandora_object' => $object,
+        '#print' => TRUE,
+      ),
+      '#states' => array(
+        'visible' => array(
+          ':input[name="metadata_toggle"]' => array('value' => 'solr_metadata'),
+        ),
+      ),
+    );
+  }
+
+  // If the Islandora module is available, add an option to the toggle and
+  // display that container.
+  if (module_exists('islandora')) {
+    $metadata_toggle_options['dc_metadata'] = t('Basic (Dublin Core) Metadata');
+
+    // Render the object's DC metadata.
+    $form['dc_metadata'] = array(
+      '#type' => 'container',
+      'metadata' => array(
+        '#theme' => 'islandora_dublin_core_display',
+        '#islandora_object' => $object,
+        '#print' => TRUE,
+      ),
+      '#states' => array(
+        'visible' => array(
+          ':input[name="metadata_toggle"]' => array('value' => 'dc_metadata'),
+        ),
+      ),
+    );
+  }
+
   // Add a form control to toggle the visbile metadata.
+  $metadata_toggle_default = (array_key_exists('solr_metadata', $metadata_toggle_options)) ? 'solr_metadata' : 'dc_metadata';
   $form['metadata_toggle'] = array(
     '#type' => 'radios',
     '#title' => t('Metadata to display'),
-    '#options' => array(
-      'dc_metadata' => t('Object metadata'),
-      'solr_metadata' => t('Solr metadata'),
-    ),
-    '#default_value' => 'dc_metadata',
-  );
-
-  // Render the object's DC metadata.
-  $form['dc_metadata'] = array(
-    '#type' => 'container',
-    'metadata' => array(
-      '#theme' => 'islandora_dublin_core_display',
-      '#islandora_object' => $object,
-      '#print' => TRUE,
-    ),
-    '#states' => array(
-      'visible' => array(
-        ':input[name="metadata_toggle"]' => array('value' => 'dc_metadata'),
-      ),
-    ),
-  );
-
-  // Render the object's Solr metadata.
-  $form['solr_metadata'] = array(
-    '#type' => 'container',
-    'metadata' => array(
-      '#theme' => 'islandora_solr_metadata_display',
-      '#islandora_object' => $object,
-      '#print' => TRUE,
-    ),
-    '#states' => array(
-      'visible' => array(
-        ':input[name="metadata_toggle"]' => array('value' => 'solr_metadata'),
-      ),
-    ),
+    '#options' => $metadata_toggle_options,
+    '#default_value' => $metadata_toggle_default,
+    '#weight' => -1,
   );
 
   return $form;

--- a/islandora_blocks.module
+++ b/islandora_blocks.module
@@ -149,6 +149,7 @@ function islandora_blocks_block_view($delta = '') {
  */
 function islandora_blocks_block_configure($delta = '') {
   $form = array();
+
   if ($delta == 'citation') {
     module_load_include('inc', 'csl', 'includes/csl');
     $form['islandora_blocks_citation_style'] = array(
@@ -159,8 +160,30 @@ function islandora_blocks_block_configure($delta = '') {
       '#element_validate' => array('islandora_blocks_configure_validate'),
     );
   }
+  elseif ($delta === 'metadata') {
+    // Allow the block administrator to choose which metadata sets are displayed
+    // in the metadata block.
+    $form['islandora_blocks_metadata_sets_display'] = array(
+      '#type' => 'checkboxes',
+      '#title' => t('Metadata sets to display'),
+      '#description' => t('Choose the sets of metadata to display. Only one dataset is displayed at a time; but if you choose more than one, a control will be shown to let the viewer toggle which set of metadata is currently shown.'),
+      '#options' => _islandora_blocks_available_metadata_sets(),
+      '#default_value' => variable_get('islandora_blocks_metadata_sets_display', array('dc_metadata' => 'dc_metadata')),
+    );
+  }
 
   return $form;
+}
+
+/**
+ * Implements hook_block_save().
+ */
+function islandora_blocks_block_save($delta = '', $edit = array()) {
+  if ($delta === 'metadata') {
+    // Allow the block administrator to choose which metadata sets are displayed
+    // in the metadata block.
+    variable_set('islandora_blocks_metadata_sets_display', $edit['islandora_blocks_metadata_sets_display']);
+  }
 }
 
 /* Form API callbacks. */
@@ -195,14 +218,17 @@ function islandora_blocks_configure_validate($form, &$form_state) {
  * @ingroup forms
  */
 function islandora_blocks_metadata_form($form, &$form_state) {
-  $metadata_toggle_options = _islandora_blocks_available_metadata_sets();
+  $available_metadata_sets = _islandora_blocks_available_metadata_sets();
+  $configured_metadata_sets = variable_get('islandora_blocks_metadata_sets_display', array('dc_metadata' => 'dc_metadata'));
+  $to_display = array_intersect_key($available_metadata_sets, $configured_metadata_sets);
 
   // The Fedora object should be the first build argument.
   $object = reset($form_state['build_info']['args']);
 
-  // If the Solr metadata is available, add an option to the toggle and display
-  // that container.
-  if (array_key_exists('solr_metadata', $metadata_toggle_options)) {
+  // If we have determined that the dependencies to display Solr metadata are
+  // available, and the block administrator wants to display Solr metadata in
+  // this block, display the container.
+  if (array_key_exists('solr_metadata', $to_display)) {
     // Find the fields we should query and display.
     module_load_include('inc', 'islandora_solr_metadata', 'includes/db');
     $associations = islandora_solr_metadata_get_associations_by_cmodels($object->models);
@@ -224,9 +250,10 @@ function islandora_blocks_metadata_form($form, &$form_state) {
     );
   }
 
-  // If the Islandora module is available, add an option to the toggle and
-  // display that container.
-  if (array_key_exists('dc_metadata', $metadata_toggle_options)) {
+  // If we have determined that the dependencies to display DC metadata are
+  // available, and the block administrator wants to display DC metadata in this
+  // block, display the container.
+  if (array_key_exists('dc_metadata', $to_display)) {
     // Render the object's DC metadata.
     $form['dc_metadata'] = array(
       '#type' => 'container',
@@ -243,15 +270,17 @@ function islandora_blocks_metadata_form($form, &$form_state) {
     );
   }
 
-  // Add a form control to toggle the visbile metadata.
-  $metadata_toggle_default = (array_key_exists('solr_metadata', $metadata_toggle_options)) ? 'solr_metadata' : 'dc_metadata';
-  $form['metadata_toggle'] = array(
-    '#type' => 'radios',
-    '#title' => t('Metadata to display'),
-    '#options' => $metadata_toggle_options,
-    '#default_value' => $metadata_toggle_default,
-    '#weight' => -1,
-  );
+  // Add a form control to toggle the visible metadata.
+  if (count($to_display) > 1) {
+    $metadata_toggle_default = (array_key_exists('solr_metadata', $available_metadata_sets)) ? 'solr_metadata' : 'dc_metadata';
+    $form['metadata_toggle'] = array(
+      '#type' => 'radios',
+      '#title' => t('Metadata to display'),
+      '#options' => $to_display,
+      '#default_value' => $metadata_toggle_default,
+      '#weight' => -1,
+    );
+  }
 
   return $form;
 }

--- a/islandora_blocks.module
+++ b/islandora_blocks.module
@@ -1,6 +1,13 @@
 <?php
 
 /**
+ * @file
+ * Hooks, callbacks, and helper functions for the Islandora Blocks module.
+ */
+
+/* Hooks. */
+
+/**
  * Implements hook_theme().
  */
 function islandora_blocks_theme($existing, $type, $theme, $path) {
@@ -37,7 +44,6 @@ function islandora_blocks_block_info() {
 
   return $blocks;
 }
-
 
 /**
  * Implements hook_block_view().
@@ -152,6 +158,18 @@ function islandora_blocks_block_configure($delta = '') {
   return $form;
 }
 
+/* Form API callbacks. */
+
+/**
+ * Element validation callback: validate citation styles.
+ *
+ * @param array $form
+ *   A form array.
+ * @param array $form_state
+ *   A form state array.
+ *
+ * @see islandora_blocks_block_configure()
+ */
 function islandora_blocks_configure_validate($form, &$form_state) {
   variable_set('islandora_blocks_citation_style', $form_state['values']['islandora_blocks_citation_style']);
 }
@@ -165,6 +183,9 @@ function islandora_blocks_configure_validate($form, &$form_state) {
  *   The form state object. Must contain the Fedora object that we want to
  *   display the metadata form as the first item in the array at
  *   $form_state['build_info']['args'].
+ *
+ * @return array
+ *   A form array for metadata.
  *
  * @ingroup forms
  */


### PR DESCRIPTION
# Problem / motivation

> As a user viewing a Fedora object, I want to see the metadata stored in Solr in addition to the Dublin Core (DC) metadata, so that I can see the most relevant metadata at a glance.

One of the functions of the `islandora_solr_metadata` module allows administrators to configure which Solr fields are displayed in which order. The displayed fields and their order can be changed separately for each CModel or set of CModels. These metadata displays can be tailored to display metadata which is most relevant to the repository, and may be more helpful for the viewer than the DC metadata.

CWRC would like a way to display both the Solr metadata in addition to the DC metadata.
# Proposed resolution

Display both the Solr metadata in the correct format for the current object's CModel, and the DC metadata. Provide a radio-button toggle to allow the user to choose which set of metadata is displayed.
# Remaining tasks
- [ ] Code review
- [ ] Commit
# User interface changes
## Metadata block configuration

A `checkboxes` control has been added to allow block administrators to choose which metadata sets are shown. 

If the `islandora` module is enabled, this control will display an option to show the DC metadata (this defaults to on, as per this module's functionality before this PR). If the `islandora_solr_metadata` module is enabled, this control will display an option to show the Solr metadata (this defaults to off, as per this module's functionality before this PR).
## Metadata block display

If the `islandora` module is enabled and the administrator chose to display the DC metadata set, this block will display the DC metadata. If the `islandora_solr_metadata` module is enabled and the administrator chose to display the Solr metadata set, this block will display the Solr metadata. Only one set of metadata will be displayed at any one time: if more than one set of metadata is displayed, a radiobutton toggle will be displayed to allow the user to choose which set. Drupal form `#states` are used to hide/show the metadata sets dynamically, without requiring a page refresh.
# API changes

None.
# Data model changes

None.
